### PR TITLE
Fixed total infected/deceased count for Poland

### DIFF
--- a/poland/src/main.js
+++ b/poland/src/main.js
@@ -39,7 +39,7 @@ Apify.main(async () => {
                 const infectedCount = region.Liczba ? parseInt(region.Liczba.replace(/ /g, '')) : 0;
                 const deceasedCount = region['Wszystkie przypadki śmiertelne'] ? parseInt(region['Wszystkie przypadki śmiertelne'].replace(/ /g, '')) : 0;
 
-                if (regionName === 'Cała Polska') {
+                if (regionName === 'Cały kraj') {
                     infectedCountTotal = infectedCount;
                     deceasedCountTotal = deceasedCount;
                 } else {


### PR DESCRIPTION
Fixed the total infected/deceased numbers for Poland as @zpelechova requested in #264 
They were missing because of recent change in field names on gov.pl