### PR TITLE
Remove broken China data source URL

### DIFF
--- a/china/README.md
+++ b/china/README.md
@@ -1,7 +1,6 @@
 # Coronavirus stats in China 
 
-Actor gets an actual number of current confirmed, confirmed, suspected, cured and deceased people by COVID-19 in China from https://github.com/BlankerL/DXY-COVID-19-Data/blob/master/json/DXYOverall.json After redesign of the page the actor takes data from https://www.worldometers.info/coronavirus/'
- .
+Actor gets an actual number of current confirmed, confirmed, suspected, cured and deceased people by COVID-19 in China from https://www.worldometers.info/coronavirus/.
 
 Latest data are available at this URL: https://api.apify.com/v2/key-value-stores/x4iHxk7TVGI7UxFv6/records/LATEST?disableRedirect=true.
 


### PR DESCRIPTION
The actor now loads data from worldometer, and the old source URL is broken, so it was also broken on the public actor page on our web. This fixes it.